### PR TITLE
sys module is not used in gzip.js

### DIFF
--- a/lib/gzip.js
+++ b/lib/gzip.js
@@ -4,8 +4,7 @@
  * MIT Licensed
  */
 
-var spawn = require('child_process').spawn,
-    sys = require('sys');
+var spawn = require('child_process').spawn;
 
 /**
  * Connect middleware providing gzip compression on the fly. By default, it


### PR DESCRIPTION
Removed unused `require('sys')` from `gzip.js`.
