### PR TITLE
rootLength variable must not be global

### DIFF
--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -37,7 +37,7 @@ exports = module.exports = function staticGzip(root, options) {
   if (!matchType.test) throw new Error('option matchType must be a regular expression');
   
   options.root = root;
-  rootLength = root.length;
+  var rootLength = root.length;
   
   return function(req, res, next) {
     var url, filename, type, acceptEncoding, ua;


### PR DESCRIPTION
This variable was declared global. If staticGzip is used more than once the last use overwrites the rootLength  and staticSend is unable to find the file as gzipped path is cut from wrong length.
