### PR TITLE
Skip compression on HEAD requests.

### DIFF
--- a/lib/gzip.js
+++ b/lib/gzip.js
@@ -64,7 +64,7 @@ exports = module.exports = function gzip(options) {
       type = res.getHeader('content-type') || '';
       encoding = res.getHeader('content-encoding');
       
-      if (code !== 200 || !~accept.indexOf('gzip') ||
+      if (req.method === 'HEAD' || code !== 200 || !~accept.indexOf('gzip') ||
           !matchType.test(type) || encoding ||
           (~ua.indexOf('MSIE 6') && !~ua.indexOf('SV1'))) {
         res.write = write;

--- a/test/gzip.test.js
+++ b/test/gzip.test.js
@@ -91,6 +91,9 @@ module.exports = {
   'gzip test compressable: multiple Accept-Encoding types': testCompressed(
     css, cssPath, { 'Accept-Encoding': 'deflate, gzip, sdch' }, cssBody, matchCss
   ),
+  'gzip test uncompressable: HEAD request': testUncompressed(
+    css, cssPath, { 'Accept-Encoding': 'gzip' }, '', matchCss, 'HEAD'
+  ),
   
   'gzip test compressable: specify --best flag': testCompressed(
     best, htmlPath, { 'Accept-Encoding': 'gzip' }, htmlBody, matchHtml

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -14,10 +14,11 @@ function wrapTest(func, numCallbacks) {
   }
 }
 
-exports.testUncompressed = function(app, url, headers, resBody, resType) {
+exports.testUncompressed = function(app, url, headers, resBody, resType, method) {
   return wrapTest(function(done) {
     assert.response(app, {
         url: url,
+        method: method ? method : 'GET',
         headers: headers
       }, {
         status: 200,
@@ -31,10 +32,11 @@ exports.testUncompressed = function(app, url, headers, resBody, resType) {
   });
 }
 
-exports.testCompressed = function(app, url, headers, resBody, resType) {
+exports.testCompressed = function(app, url, headers, resBody, resType, method) {
   return wrapTest(function(done) {
     assert.response(app, {
         url: url,
+        method: method ? method : 'GET',
         headers: headers,
         encoding: 'binary'
       }, {


### PR DESCRIPTION
With this middleware enabled, every HEAD request that matches the filters will cause the following warning to be printed:

```
This type of response MUST NOT have a body. Ignoring write() calls.
```

This checks that `req.method !== 'HEAD'` before compressing. This is a simple fix and matches the future compress middleware that is going to be included with connect.
