### PR TITLE
child_process.spawn now uses the close event

### DIFF
--- a/lib/gzip.js
+++ b/lib/gzip.js
@@ -51,6 +51,7 @@ exports = module.exports = function gzip(options) {
       var args = Array.prototype.slice.call(arguments, 0),
           write = defaults.write,
           end = defaults.end,
+          version = process.versions.node.split('.'),
           headers, key, accept, type, encoding, gzip, ua;
       if (args.length > 1) {
         headers = args.pop();
@@ -93,7 +94,7 @@ exports = module.exports = function gzip(options) {
         write.call(res, chunk);
       });
 
-      gzip.addListener('exit', function(code) {
+      gzip.addListener(version[0] === 0 && version[1] < 7 ? "exit" : "close", function(code) {
         res.write = write;
         res.end = end;
         res.end();

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -90,14 +90,16 @@ exports.testMaxAge = function(app, url, headers, maxAge) {
 function gunzip(data, callback) {
   var process = spawn('gunzip', ['-c']),
       out = '',
-      err = '';
+      err = '',
+      version = process.versions.node.split('.');
+
   process.stdout.on('data', function(data) {
     out += data;
   });
   process.stderr.on('data', function(data) {
     err += data;
   });
-  process.on('exit', function(code) {
+  process.on(version[0] === 0 && version[1] < 7 ? "exit" : "close", function(code) {
     if (callback) callback(err, out);
   });
   process.stdin.end(data, 'binary');


### PR DESCRIPTION
`child_process.spawn` in Node.js versions prior to 0.7 use the `exit` event to signal that the child process has finished; newer versions use the `close` event. Listening to the `exit` event in version >= 0.7 will result in occasional data loss if the `exit` event fires before `close`.
